### PR TITLE
Class 14 pyramid templating

### DIFF
--- a/pyramid_stocks/pyramid_stocks/sample_data/__init__.py
+++ b/pyramid_stocks/pyramid_stocks/sample_data/__init__.py
@@ -12,7 +12,7 @@ MOCK_ENTRIES = [
     },
     {
         "symbol": "VA",
-        "companyName": "valve",
+        "companyName": "Valve",
         "exchange": "Baller Exchange",
         "industry": "Makin' Money",
         "website": "valvesoftware.com",

--- a/pyramid_stocks/pyramid_stocks/templates/base.jinja2
+++ b/pyramid_stocks/pyramid_stocks/templates/base.jinja2
@@ -12,8 +12,9 @@
     <nav>
       <ul>
         <li><a href={{request.route_url('home')}}>Home</a></li>
-        <li><a href={{request.route_url('auth')}}>Auth</a></li>
+        <li><a href={{request.route_url('auth')}}>Sign in</a></li>
         <li><a href={{request.route_url('portfolio')}}>Portfolio</a></li>
+        <li><a href="{{request.route_url('stock')}}">Add Stocks</a></li>
       </ul>
     </nav>
   </header>

--- a/pyramid_stocks/pyramid_stocks/templates/details.jinja2
+++ b/pyramid_stocks/pyramid_stocks/templates/details.jinja2
@@ -1,5 +1,15 @@
 {% extends "base.jinja2" %}
 
 {% block content %}
-
+<h1>{{stock.companyName}} Details</h1>
+<ul>
+  <li>Website: {{stock.website}}</li>
+  <li>CEO: {{stock.CEO}}</li>
+  <li>Symbol: {{stock.symbol}}</li>
+  <li>Exchange: {{stock.exchange}}</li>
+  <li>Industry: {{stock.industry}}</li>
+  <li>Description: {{stock.description}}</li>
+  <li>Issue Type: {{stock.issueType}}</li>
+  <li>Sector: {{stock.sector}}</li>
+</ul>
 {% endblock content %}

--- a/pyramid_stocks/pyramid_stocks/templates/details.jinja2
+++ b/pyramid_stocks/pyramid_stocks/templates/details.jinja2
@@ -1,0 +1,5 @@
+{% extends "base.jinja2" %}
+
+{% block content %}
+
+{% endblock content %}

--- a/pyramid_stocks/pyramid_stocks/templates/portfolio.jinja2
+++ b/pyramid_stocks/pyramid_stocks/templates/portfolio.jinja2
@@ -6,7 +6,7 @@
   {% for entry in portfolio %}
   <li>
     <h3>{{entry.companyName}}</h3>
-    <p><a href="{{request.route_url('portfolio', id=entry.symbol)}}">view more</a></p>
+    <p><a href="{{request.route_url('details', symbol=entry.symbol)}}">view more</a></p>
   </li>
   {% endfor %}
 </ul>

--- a/pyramid_stocks/pyramid_stocks/templates/stock-add.jinja2
+++ b/pyramid_stocks/pyramid_stocks/templates/stock-add.jinja2
@@ -1,0 +1,18 @@
+{% extends "base.jinja2" %}
+
+{% block content %}
+<form action="{{request.route_url('stock')}}" method="GET">
+  <input type="text" name="symbol" placeholder="MSFT">
+  <button type="submit">search</button>
+</form>
+
+{% if company %}
+<div>
+  <h1>Result</h1>
+  <h2>{{company.companyName}}</h2>
+  <form action="{{request.route_url('stock')}}" method="POST">
+    <button type="submit">search</button>
+  </form>
+</div>
+{% endif %}
+{% endblock content %}

--- a/pyramid_stocks/pyramid_stocks/tests/conftest.py
+++ b/pyramid_stocks/pyramid_stocks/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from pyramid import testing
+
+
+@pytest.fixture
+def dummy_request():
+    return testing.DummyRequest()

--- a/pyramid_stocks/pyramid_stocks/tests/test_views.py
+++ b/pyramid_stocks/pyramid_stocks/tests/test_views.py
@@ -1,0 +1,19 @@
+def test_default_behavior_of_home_view(dummy_request):
+    from ..views.default import get_home_view
+    response = get_home_view(dummy_request)
+    assert isinstance(response, dict)
+    assert response == {}
+
+
+def test_default_behavior_of_auth_view(dummy_request):
+    from ..views.default import get_auth_view
+    response = get_auth_view(dummy_request)
+    assert isinstance(response, dict)
+    assert response == {}
+
+
+def test_default_behavior_of_portfolio_view(dummy_request):
+    from ..views.default import get_portfolio_view
+    response = get_portfolio_view(dummy_request)
+    assert type(response) == dict
+    assert response['portfolio'][0]['companyName'] == 'Kojima Productions'

--- a/pyramid_stocks/pyramid_stocks/views/default.py
+++ b/pyramid_stocks/pyramid_stocks/views/default.py
@@ -35,12 +35,12 @@ def get_auth_view(request):
 
 
 @view_config(route_name='portfolio', renderer='../templates/portfolio.jinja2')
-def get_portfolio(request):
+def get_portfolio_view(request):
     return {'portfolio': MOCK_ENTRIES}
 
 
 @view_config(route_name='details', renderer='../templates/details.jinja2')
-def my_detail_view(request):
+def get_detail_view(request):
     symbol = request.matchdict['symbol']
     for entry in MOCK_ENTRIES:
         if entry['symbol'] == symbol:
@@ -50,7 +50,7 @@ def my_detail_view(request):
 
 
 @view_config(route_name='stock', renderer='../templates/stock-add.jinja2')
-def my_stock_view(request):
+def get_stock_view(request):
     if request.method == 'GET':
         try:
             symbol = request.GET['symbol']

--- a/pyramid_stocks/pyramid_stocks/views/default.py
+++ b/pyramid_stocks/pyramid_stocks/views/default.py
@@ -2,6 +2,10 @@
 from pyramid.view import view_config
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from ..sample_data import MOCK_ENTRIES
+import requests
+
+
+API_URL = 'https://api.iextrading.com/1.0'
 
 
 @view_config(route_name='home', renderer='../templates/base.jinja2')
@@ -16,7 +20,6 @@ def get_auth_view(request):
             username = request.GET['username']
             password = request.GET['password']
             print('User: {}, Pass: {}'.format(username, password))
-
             return HTTPFound(location=request.route_url('portfolio'))
 
         except KeyError:
@@ -26,7 +29,6 @@ def get_auth_view(request):
         username = request.POST['username']
         password = request.POST['password']
         print('User: {}, Pass: {}'.format(username, password))
-
         return HTTPFound(location=request.route_url('portfolio'))
 
     return HTTPNotFound()
@@ -37,7 +39,27 @@ def get_portfolio(request):
     return {'portfolio': MOCK_ENTRIES}
 
 
-@view_config(route_name='details',
-             renderer='../templates/details.jinja2')
-def get_portfolo_symbol_view(request):
-    return {'portfolio': MOCK_ENTRIES}
+@view_config(route_name='details', renderer='../templates/details.jinja2')
+def my_detail_view(request):
+    symbol = request.matchdict['symbol']
+    for entry in MOCK_ENTRIES:
+        if entry['symbol'] == symbol:
+            return {'stock': entry}
+
+    return {}
+
+
+@view_config(route_name='stock', renderer='../templates/stock-add.jinja2')
+def my_stock_view(request):
+    if request.method == 'GET':
+        try:
+            symbol = request.GET['symbol']
+        except KeyError:
+            return {}
+
+        response = requests.get(API_URL + '/stock/{}/company'.format(symbol))
+        data = response.json()
+        return {'company': data}
+
+    else:
+        raise HTTPNotFound()


### PR DESCRIPTION
[x] Your Jinja2 templates should use template inheritance instead of repeating any of the site's layout
[x] Your template's links to the app itself, the navigation items, should be done using request.route_url instead of being hardcoded
[x] Your CSS, JavaScript, or image files that are stored in your static directory should be included with request.static_url instead of being hardcoded
[x] Your /portfolio route should use a {% for %} loop to populate the stock list using the data in sample_data/__init__.py
[x] Your /portfolio/{symbol} route should populate the data for the page based on the data from sample_data/__init__.py
[x] /auth, when submitted, should redirect the user to the portfolio page. No need to worry about distinguishing your forms on the page at this point. POST /auth for your signup and GET /auth for your signin, are sufficient.